### PR TITLE
macOS mod folder location fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
-def mainClass = "net.tttprojekt.cascademode.Main"
+def mainClass = "net.tttprojekt.installer.Main"
 tasks.build.dependsOn tasks.shadowJar
 
 group 'net.tttprojekt'

--- a/src/main/java/net/tttprojekt/installer/Launcher.java
+++ b/src/main/java/net/tttprojekt/installer/Launcher.java
@@ -1,12 +1,12 @@
-package net.tttprojekt.cascademode;
+package net.tttprojekt.installer;
 
 import lombok.Getter;
-import net.tttprojekt.cascademode.download.DownloadTaskManager;
-import net.tttprojekt.cascademode.gui.GUI;
-import net.tttprojekt.cascademode.installer.ForgeInstaller;
-import net.tttprojekt.cascademode.installer.IForgeInstaller;
-import net.tttprojekt.cascademode.installer.IModInstaller;
-import net.tttprojekt.cascademode.installer.ModInstaller;
+import net.tttprojekt.installer.download.DownloadTaskManager;
+import net.tttprojekt.installer.gui.GUI;
+import net.tttprojekt.installer.installer.ForgeInstaller;
+import net.tttprojekt.installer.installer.IForgeInstaller;
+import net.tttprojekt.installer.installer.IModInstaller;
+import net.tttprojekt.installer.installer.ModInstaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/tttprojekt/installer/Main.java
+++ b/src/main/java/net/tttprojekt/installer/Main.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode;
+package net.tttprojekt.installer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/tttprojekt/installer/download/Download.java
+++ b/src/main/java/net/tttprojekt/installer/download/Download.java
@@ -1,8 +1,8 @@
-package net.tttprojekt.cascademode.download;
+package net.tttprojekt.installer.download;
 
-import net.tttprojekt.cascademode.utils.FileDestination;
-import net.tttprojekt.cascademode.utils.OptiFineFetcher;
-import net.tttprojekt.cascademode.utils.OptiFineVersion;
+import net.tttprojekt.installer.utils.FileDestination;
+import net.tttprojekt.installer.utils.OptiFineFetcher;
+import net.tttprojekt.installer.utils.OptiFineVersion;
 
 public enum Download {
 

--- a/src/main/java/net/tttprojekt/installer/download/DownloadTask.java
+++ b/src/main/java/net/tttprojekt/installer/download/DownloadTask.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.download;
+package net.tttprojekt.installer.download;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/tttprojekt/installer/download/DownloadTaskManager.java
+++ b/src/main/java/net/tttprojekt/installer/download/DownloadTaskManager.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.download;
+package net.tttprojekt.installer.download;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;

--- a/src/main/java/net/tttprojekt/installer/gui/GUI.java
+++ b/src/main/java/net/tttprojekt/installer/gui/GUI.java
@@ -1,11 +1,11 @@
-package net.tttprojekt.cascademode.gui;
+package net.tttprojekt.installer.gui;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.tttprojekt.cascademode.Main;
-import net.tttprojekt.cascademode.installer.IForgeInstaller;
-import net.tttprojekt.cascademode.installer.IModInstaller;
-import net.tttprojekt.cascademode.utils.MinecraftChecker;
+import net.tttprojekt.installer.Main;
+import net.tttprojekt.installer.installer.IForgeInstaller;
+import net.tttprojekt.installer.installer.IModInstaller;
+import net.tttprojekt.installer.utils.MinecraftChecker;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/net/tttprojekt/installer/installer/ForgeInstaller.java
+++ b/src/main/java/net/tttprojekt/installer/installer/ForgeInstaller.java
@@ -1,9 +1,9 @@
-package net.tttprojekt.cascademode.installer;
+package net.tttprojekt.installer.installer;
 
-import net.tttprojekt.cascademode.download.Download;
-import net.tttprojekt.cascademode.download.DownloadTaskManager;
-import net.tttprojekt.cascademode.utils.FileDestination;
-import net.tttprojekt.cascademode.utils.ProcessUtils;
+import net.tttprojekt.installer.download.Download;
+import net.tttprojekt.installer.download.DownloadTaskManager;
+import net.tttprojekt.installer.utils.FileDestination;
+import net.tttprojekt.installer.utils.ProcessUtils;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/tttprojekt/installer/installer/IForgeInstaller.java
+++ b/src/main/java/net/tttprojekt/installer/installer/IForgeInstaller.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.installer;
+package net.tttprojekt.installer.installer;
 
 public interface IForgeInstaller {
 

--- a/src/main/java/net/tttprojekt/installer/installer/IModInstaller.java
+++ b/src/main/java/net/tttprojekt/installer/installer/IModInstaller.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.installer;
+package net.tttprojekt.installer.installer;
 
 public interface IModInstaller {
 

--- a/src/main/java/net/tttprojekt/installer/installer/ModInstaller.java
+++ b/src/main/java/net/tttprojekt/installer/installer/ModInstaller.java
@@ -1,11 +1,11 @@
-package net.tttprojekt.cascademode.installer;
+package net.tttprojekt.installer.installer;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
-import net.tttprojekt.cascademode.download.DownloadTaskManager;
-import net.tttprojekt.cascademode.download.Download;
-import net.tttprojekt.cascademode.utils.FileDestination;
+import net.tttprojekt.installer.download.DownloadTaskManager;
+import net.tttprojekt.installer.download.Download;
+import net.tttprojekt.installer.utils.FileDestination;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/tttprojekt/installer/utils/FileDestination.java
+++ b/src/main/java/net/tttprojekt/installer/utils/FileDestination.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.utils;
+package net.tttprojekt.installer.utils;
 
 import java.io.File;
 import java.nio.file.Paths;

--- a/src/main/java/net/tttprojekt/installer/utils/FileDestination.java
+++ b/src/main/java/net/tttprojekt/installer/utils/FileDestination.java
@@ -21,7 +21,7 @@ public class FileDestination {
         if (osType.contains("win") && System.getenv("APPDATA") != null)
             return new File(System.getenv("APPDATA"), mcDir);
         if (osType.contains("mac"))
-            return new File(new File(new File(userHomeDir, "Library"), "Application Support"), "minecraft");
+            return new File(new File(new File(new File(userHomeDir, "Library"), "Application Support"), "minecraft"), "mods");
         return new File(userHomeDir, mcDir);
     }
 

--- a/src/main/java/net/tttprojekt/installer/utils/MinecraftChecker.java
+++ b/src/main/java/net/tttprojekt/installer/utils/MinecraftChecker.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.utils;
+package net.tttprojekt.installer.utils;
 
 import java.util.List;
 

--- a/src/main/java/net/tttprojekt/installer/utils/OptiFineFetcher.java
+++ b/src/main/java/net/tttprojekt/installer/utils/OptiFineFetcher.java
@@ -1,11 +1,11 @@
-package net.tttprojekt.cascademode.utils;
+package net.tttprojekt.installer.utils;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSpan;
-import net.tttprojekt.cascademode.download.DownloadTask;
+import net.tttprojekt.installer.download.DownloadTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/net/tttprojekt/installer/utils/OptiFineVersion.java
+++ b/src/main/java/net/tttprojekt/installer/utils/OptiFineVersion.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.utils;
+package net.tttprojekt.installer.utils;
 
 import lombok.Getter;
 

--- a/src/main/java/net/tttprojekt/installer/utils/ProcessUtils.java
+++ b/src/main/java/net/tttprojekt/installer/utils/ProcessUtils.java
@@ -1,4 +1,4 @@
-package net.tttprojekt.cascademode.utils;
+package net.tttprojekt.installer.utils;
 
 import com.google.common.collect.Lists;
 


### PR DESCRIPTION
This pull request fixes an issue where on macOS the mod folder directory pointed to the minecraft folder. This causes the Minecraft folder to be deleted instead of the mod folder.